### PR TITLE
Escape spaces in `$PWD` variable in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -eu
 
 PWD=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 
-pushd $PWD
+pushd "$PWD"
 
 git submodule update --init
 


### PR DESCRIPTION
After adding `cryplot` dependency to  my `shard.yml` file and running `shards install`, I get this error:
``` bash
Resolving dependencies
Fetching https://github.com/naqvis/cryplot.git
Installing cryplot (0.1.1)
Postinstall of cryplot: ./install.sh
Failed postinstall of cryplot on ./install.sh:
./install.sh: 5: ./install.sh: Bad substitution
./install.sh: 7: ./install.sh: pushd: not found

```

The problem was that my  project path contains some spaces that were not escaped when calling `pushd $PWD` in [`install.sh`](https://github.com/naqvis/cryplot/blob/63cfd3703d5f15bf874380a0f2cc0a661a78dca2/install.sh#L7C1-L7C11). This pull request solves this problem by adding two double quote (`"`) around `PWD` variable in [`install.sh`](https://github.com/SlimBenAmor/cryplot/blob/bf1160f8a4e4fa4765ef899db8979cc000d51286/install.sh#L7).