### PR TITLE
shards install breaks due to usage of bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -eu
 
-PWD=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
-
-pushd "$PWD"
+cd $(dirname $0)
 
 git submodule update --init
 
@@ -15,5 +13,3 @@ then
 fi
 
 crystal run scripts/gen_palettes.cr
-
-popd

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,16 @@ cd $(dirname $0)
 
 git submodule update --init
 
-if [ ! -d "deps/gnuplot-palettes" ]
+if [ ! -e "deps/gnuplot-palettes/accent.pal" ]
 then
     echo "missing directory 'deps/gnuplot-palettes'. Seems  git submodule didn't work"
+    echo "trying direct clone of latest..."
+    git clone https://github.com/naqvis/gnuplot-palettes deps/gnuplot-palettes
+fi
+
+if [ ! -e "deps/gnuplot-palettes/accent.pal" ]
+then
+    echo "git clone didn't work either"
     exit 2
 fi
 


### PR DESCRIPTION
It seems `shards install` invokes the install script using `sh`. The script directory pop seems unnecessary, so I simplified.